### PR TITLE
Add GitHub Skills Activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub's certification program",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
This PR adds the missing "GitHub Skills" activity to the activities list in `src/app.py`. 

The activity was announced by the principal but was not available for registration. This fix addresses issue #6 by adding the activity with appropriate details.

- Description: Learn practical coding and collaboration skills through GitHub's certification program
- Schedule: Mondays and Wednesdays, 3:30 PM - 4:30 PM
- Max participants: 25
- Participants: [] (starts empty)

This is time-sensitive as registrations close by the end of the week.